### PR TITLE
remove class property syntax

### DIFF
--- a/src/players/Handler.js
+++ b/src/players/Handler.js
@@ -1,9 +1,4 @@
 class PlayerHandler {
-  os;
-  name;
-  source;
-  id;
-
   constructor({ name, os, source, id }) {
     this.name = name;
     this.os = os;


### PR DESCRIPTION
Don't need a babel plugin if you remove the syntax

![image](https://user-images.githubusercontent.com/424987/66260078-c8099200-e76e-11e9-82be-d4edc7dd67a8.png)
